### PR TITLE
Add pyupgrade to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v1.22.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py36-plus"]
+
   - repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:


### PR DESCRIPTION
Mainly to test the latest changes to PyPI's token upload beta, by deploying to Test PyPI on a master merge.

* https://pythoninsider.blogspot.com/2019/07/pypi-now-supports-uploading-via-api.html
* https://discuss.python.org/t/pypi-security-work-multifactor-auth-progress-help-needed/1042/43

The old stuff changed in https://github.com/hugovk/tinytext/commit/5dd6f4f37f34e355fdac2be6f6be8f7f25b3fbd1 has been removed from PyPI (Warehouse).
