### PR TITLE
Test with GitHub Actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ exclude_lines =
     # Have to re-enable the standard pragma:
     pragma: no cover
 
+    # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
 
 [run]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+
+    - name: Lint
+      run: tox -e lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Upload coverage to Codecov
       run: |
         python -m pip install --upgrade codecov
-        codecov -t ${{secrets.CODECOV_TOKEN}}
+        codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}" --token ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,10 @@ jobs:
       run: |
         tox -e py`echo ${{ matrix.python-version }} | tr -d .`
 
-    # TODO Upload to Codecov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.2
+      with:
+        token: ${{secrets.CODECOV_TOKEN}} #required
+#        file: ./coverage.xml #optional
+#        flags: unittests #optional
+#        name: codecov-umbrella #optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,6 @@ jobs:
     - name: Upload coverage to Codecov
       run: |
         python -m pip install --upgrade codecov
-        codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}" --token ${{secrets.CODECOV_TOKEN}}
+        codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,10 @@ jobs:
         python -m pip install --upgrade tox
         python -m pip install  -e .
 
-    - name: Unit tests
+    - name: Tox tests
       shell: bash
       # Drop the dot: py3.7 -> py37
       run: |
         tox -e py`echo ${{ matrix.python-version }} | tr -d .`
-
-    - name: Test runs
-      run: |
-        pypistats --help
-        pypistats recent --help
 
     # TODO Upload to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,6 @@ jobs:
         tox -e py`echo ${{ matrix.python-version }} | tr -d .`
 
     - name: Upload coverage to Codecov
-      run: bash <(curl -s 'https://codecov.io/bash') -Z -J 'tinytext' -X gcov -X fix -t ${{secrets.CODECOV_TOKEN}}
+      run: |
+        python -m pip install --upgrade codecov
+        codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Upload coverage to Codecov
       run: |
         python -m pip install --upgrade codecov
-        codecov
+        codecov -t ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+        python -m pip install  -e .
+
+    - name: Unit tests
+      shell: bash
+      # Drop the dot: py3.7 -> py37
+      run: |
+        tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+
+    - name: Test runs
+      run: |
+        pypistats --help
+        pypistats recent --help
+
+    # TODO Upload to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,4 @@ jobs:
         tox -e py`echo ${{ matrix.python-version }} | tr -d .`
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.2
-      with:
-        token: ${{secrets.CODECOV_TOKEN}} #required
-#        file: ./coverage.xml #optional
-#        flags: unittests #optional
-#        name: codecov-umbrella #optional
+      run: bash <(curl -s 'https://codecov.io/bash') -Z -J 'tinytext' -X gcov -X fix -t ${{secrets.CODECOV_TOKEN}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.22.1
+    rev: v1.23.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -27,7 +27,7 @@ repos:
         language_version: python3.7
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: python-check-blanket-noqa
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2019 Hugo van Kemenade
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ tinytext
 [![PyPI](https://img.shields.io/pypi/v/tinytext.svg)](https://pypi.org/project/tinytext)
 [![Python versions](https://img.shields.io/pypi/pyversions/tinytext.svg)](https://pypi.org/project/tinytext)
 [![Build Status](https://travis-ci.org/hugovk/tinytext.svg?branch=master)](https://travis-ci.org/hugovk/tinytext)
+[![Actions Status](https://github.com/hugovk/tinytext/workflows/Test/badge.svg)](https://github.com/hugovk/tinytext/actions)
 [![codecov](https://codecov.io/gh/hugovk/tinytext/branch/master/graph/badge.svg)](https://codecov.io/gh/hugovk/tinytext)
+[![GitHub](https://img.shields.io/github/license/hugovk/tinytext.svg)](LICENSE.txt)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 Convert your text ᶦᶰᵗᵒ ᵗᶦᶰᶦᵉʳ ᵗᵉˣᵗ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-py36 = true
+target_version = ['py36']

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,14 @@
 universal = 1
 
 [flake8]
-max-line-length = 88
+max_line_length = 88
+
+[metadata]
+license_file = LICENSE.txt
+
+[tool:isort]
+force_grid_wrap = 0
+include_trailing_comma = True
+line_length = 88
+multi_line_output = 3
+use_parentheses = True

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 from setuptools import find_packages, setup
 
 with open("README.md") as f:
@@ -18,6 +17,7 @@ setup(
     long_description_content_type="text/markdown",
     author="hugovk",
     url="https://github.com/hugovk/tinytext",
+    license="MIT",
     keywords=[
         "botally",
         "tiny type",
@@ -50,5 +50,3 @@ setup(
         "Topic :: Text Processing",
     ],
 )
-
-# End of file

--- a/src/tinytext/__init__.py
+++ b/src/tinytext/__init__.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution(__name__).version

--- a/src/tinytext/cli.py
+++ b/src/tinytext/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 CLI for tinytext
 """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# encoding: utf-8

--- a/tests/test_tinytext.py
+++ b/tests/test_tinytext.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 from __future__ import print_function, unicode_literals
 
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     pytest-cov
 commands =
+    # Unit tests
     {envpython} -m pytest --cov tinytext --cov tests {posargs}
 
     # Test runs


### PR DESCRIPTION
For coverage:

1. Get a Codecov upload token:
   * https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found- 
   * https://codecov.io/gh/hugovk/tinytext/settings

2. Save it as `CODECOV_TOKEN` at https://github.com/hugovk/tinytext/settings/secrets

This probably won't work for forks. Azure Pipelines has a workaround to "Make secrets available to builds of forks":

* https://hynek.me/articles/simple-python-azure-pipelines/#coverage

And with this AP workaround:

> Please note that this token can leak despite being a “secret” variable. A malicious user can open a PR and send it anywhere they want. However, the token is worthless for anything except uploading coverage and it’s easy to see when someone does it.

So a GHA workaround would be to put the token in plaintext.
