### PR TITLE
Remove MANIFEST.in + testing updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,22 +7,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v1
 
       - name: pip cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: ${{ github.workflow }}-${{ matrix.python-version }}
+          key: ${{ matrix.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-pip-
 
       - name: pre-commit cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: ${{ github.workflow }}-${{ matrix.python-version }}
+          key:
+            ${{ matrix.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ matrix.os }}-pre-commit-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,24 +4,23 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
 
-    - name: Lint
-      run: tox -e lint
+      - name: Lint
+        run: tox -e lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: pip cache
+        uses: actions/cache@preview
+        with:
+          path: ~/.cache/pip
+          key: lint-${{ matrix.python-version }}-pip
+
+      - name: pre-commit cache
+        uses: actions/cache@preview
+        with:
+          path: ~/.cache/pre-commit
+          key: lint-${{ matrix.python-version }}-pre-commit
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,13 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.cache/pip
-          key: lint-${{ matrix.python-version }}-pip
+          key: ${{ github.workflow }}-${{ matrix.python-version }}
 
       - name: pre-commit cache
         uses: actions/cache@preview
         with:
           path: ~/.cache/pre-commit
-          key: lint-${{ matrix.python-version }}-pre-commit
+          key: ${{ github.workflow }}-${{ matrix.python-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,26 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Ubuntu cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+          key:
+            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-${{
+            hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: macOS cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         if: startsWith(matrix.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+          key:
+            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-${{
+            hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7"]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, ubuntu-16.04, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1
@@ -22,7 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox
-          python -m pip install  -e .
+          python -m pip install -e .
 
       - name: Tox tests
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.6", "3.7", "3.8"]
         os: [ubuntu-latest, ubuntu-16.04, macOS-latest]
 
     steps:
@@ -19,14 +19,14 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
+          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: macOS cache
         uses: actions/cache@preview
         if: startsWith(matrix.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
+          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
-        os: [ubuntu-latest, ubuntu-16.04, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-16.04, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1
@@ -20,10 +20,10 @@ jobs:
         with:
           path: ~/.cache/pip
           key:
-            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-${{
-            hashFiles('setup.py') }}
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
           restore-keys: |
-            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: macOS cache
         uses: actions/cache@v1
@@ -31,10 +31,10 @@ jobs:
         with:
           path: ~/Library/Caches/pip
           key:
-            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-${{
-            hashFiles('setup.py') }}
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
           restore-keys: |
-            ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
+
+      - uses: actions/cache@preview
+        if: startsWith(matrix.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -12,28 +11,28 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox
-        python -m pip install  -e .
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+          python -m pip install  -e .
 
-    - name: Tox tests
-      shell: bash
-      # Drop the dot: py3.7 -> py37
-      run: |
-        tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+      - name: Tox tests
+        shell: bash
+        # Drop the dot: py3.7 -> py37
+        run: |
+          tox -e py`echo ${{ matrix.python-version }} | tr -d .`
 
-    - name: Upload coverage to Codecov
-      run: |
-        python -m pip install --upgrade codecov
-        codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        run: |
+          python -m pip install --upgrade codecov
+          codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: actions/cache@preview
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - uses: actions/cache@preview
+        if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: actions/cache@preview
+      - name: Ubuntu cache
+        uses: actions/cache@preview
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
           key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
 
-      - uses: actions/cache@preview
+      - name: macOS cache
+        uses: actions/cache@preview
         if: startsWith(matrix.os, 'macOS')
         with:
           path: ~/Library/Caches/pip

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/_build/
 target/
 
 node_modules/
+
+# pyenv
+.python-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
+        args: ["--target-version", "py36"]
         # override until resolved: https://github.com/psf/black/issues/402
         files: \.pyi?$
         types: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.1
+    rev: v1.25.2
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -38,12 +38,12 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.740
+    rev: v0.750
     hooks:
       - id: mypy
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.18.2
+    rev: 1.19.1
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.24.1
+    rev: v1.25.1
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -25,7 +25,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.1
+    rev: v1.4.2
     hooks:
       - id: python-check-blanket-noqa
 
@@ -37,6 +37,12 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.730
+    rev: v0.740
     hooks:
       - id: mypy
+
+  - repo: https://github.com/prettier/prettier
+    rev: 1.18.2
+    hooks:
+      - id: prettier
+        args: [--prose-wrap=always, --print-width=88]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
         # override until resolved: https://github.com/psf/black/issues/402
@@ -14,7 +14,7 @@ repos:
         types: []
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
@@ -30,7 +30,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=lint
     - python: 3.8
     - python: 3.7

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,35 +1,30 @@
 module.exports = function(grunt) {
-
-
-  var srcFiles = ['**/*.py'];
+  var srcFiles = ["**/*.py"];
 
   // Project configuration.
   grunt.initConfig({
-
     flake8: {
       options: {
         // Task-specific options go here.
-        spawn: false,
+        spawn: false
       },
-      src: srcFiles,
+      src: srcFiles
     },
 
     exec: {
-      run_tests: 'coverage run --source=tinytext tests/test_tinytext.py && coverage report'
+      run_tests:
+        "coverage run --source=tinytext tests/test_tinytext.py && coverage report"
     },
 
     watch: {
       files: srcFiles,
-      tasks: ['exec', 'flake8']
-    },
-
+      tasks: ["exec", "flake8"]
+    }
   });
 
+  grunt.loadNpmTasks("grunt-contrib-watch");
+  grunt.loadNpmTasks("grunt-exec");
+  grunt.loadNpmTasks("grunt-flake8");
 
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-exec');
-  grunt.loadNpmTasks('grunt-flake8');
-
-  grunt.registerTask('default', ['watch']);
-
+  grunt.registerTask("default", ["watch"]);
 };

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include *.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Helpful for all your tiny cute needs.
 
 Especially helpful for cute bot needs.
 
-A Python port of [Rachel White's tiny-text for Node](https://github.com/rachelnicole/tiny-text).
+A Python port of
+[Rachel White's tiny-text for Node](https://github.com/rachelnicole/tiny-text).
 
 ## How to use
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,24 +1,31 @@
 # Release Checklist
 
-* [ ] Get master to the appropriate code release state. [Travis CI](https://travis-ci.org/hugovk/tinytext) should be running cleanly for all merges to master.
+- [ ] Get master to the appropriate code release state.
+      [Travis CI](https://travis-ci.org/hugovk/tinytext) should be running cleanly for
+      all merges to master.
 
-* [ ] Tag with the version number:
+- [ ] Tag with the version number:
+
 ```bash
 git tag -a 2.1.0 -m "Release 2.1.0"
 ```
 
-* [ ] Push tag:
- ```bash
+- [ ] Push tag:
+
+```bash
 git push --tags
 ```
 
-* [ ] Create new GitHub release: https://github.com/hugovk/tinytext/releases/new
-  * Tag: Pick existing tag "2.1.0"
-  * Title: "Release 2.1.0"
+- [ ] Create new GitHub release: https://github.com/hugovk/tinytext/releases/new
 
-* [ ] Check the tagged [Travis CI build](https://travis-ci.org/hugovk/tinytext) has deployed to [PyPI](https://pypi.org/project/tinytext/#history)
+  - Tag: Pick existing tag "2.1.0"
+  - Title: "Release 2.1.0"
 
-* [ ] Check installation:
+- [ ] Check the tagged [Travis CI build](https://travis-ci.org/hugovk/tinytext) has
+      deployed to [PyPI](https://pypi.org/project/tinytext/#history)
+
+- [ ] Check installation:
+
 ```bash
 pip3 uninstall -y tinytext && pip3 install -U tinytext
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@ universal = 1
 [flake8]
 max_line_length = 88
 
-[metadata]
-license_file = LICENSE.txt
-
 [tool:isort]
 force_grid_wrap = 0
 include_trailing_comma = True


### PR DESCRIPTION
When using setuptools_scm, MANIFEST.in is needed when we want to exclude tracked files, or include untracked files.

* https://github.com/pypa/setuptools_scm/blob/master/README.rst#file-finders-hook-makes-most-of-manifestin-unnecessary

---

Also adjustments to testing and formatting, see commit messages for details.