### PR TITLE
Only Python 3 is supported: don't create universal wheel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,10 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-2020]
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub Actions status](https://github.com/hugovk/tinytext/workflows/Test/badge.svg)](https://github.com/hugovk/tinytext/actions)
 [![codecov](https://codecov.io/gh/hugovk/tinytext/branch/master/graph/badge.svg)](https://codecov.io/gh/hugovk/tinytext)
 [![GitHub](https://img.shields.io/github/license/hugovk/tinytext.svg)](LICENSE.txt)
-[![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
 Convert your text ᶦᶰᵗᵒ ᵗᶦᶰᶦᵉʳ ᵗᵉˣᵗ
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max_line_length = 88
 


### PR DESCRIPTION
The wheel filename contained `py2.py3`, indicating Python 2 support.

# Universal Wheels

> _Universal Wheels_ are wheels that are pure Python (i.e. contain no compiled extensions) and support Python 2 and 3. This is a wheel that can be installed anywhere by pip.
...
> Only use the `--universal` setting, if:
> * Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
> * Your project does not have any C extensions.
>
> Beware that `bdist_wheel` does not currently have any checks to warn if you use the setting inappropriately.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

# Pure Python Wheels

> _Pure Python Wheels_ that are not “universal” are wheels that are pure Python (i.e. contain no compiled extensions), but don’t natively support both Python 2 and 3.
...
> `bdist_wheel` will detect that the code is pure Python, and build a wheel that’s named such that it’s usable on any Python installation with the same major version (Python 2 or Python 3) as the version you used to build the wheel.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#pure-python-wheels
