### PR TITLE
Trigger on published release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '[0-9]+\.[0-9]+\.[0-9]+'
+  release:
+    types:
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
2.3.5 wasn't deployed to PyPI, because the Action didn't trigger.

I think this is because I didn't push a tag, like when manually deploying, but it was created when the draft release was published.

Let's try this. It's possible `if: startsWith(github.event.ref, 'refs/tags')` won't match, but we'll see.