### PR TITLE
Deploy to PyPI when event = published

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           twine check dist/*
 
       - name: Publish package to PyPI
-        if: startsWith(github.event.ref, 'refs/tags')
+        if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
Continuation of https://github.com/hugovk/tinytext/pull/23 and https://github.com/hugovk/tinytext/pull/27.

2.3.6 wasn't deployed to PyPI, the Action triggered but as expected, the step was skipped because `if: startsWith(github.event.ref, 'refs/tags')` didn't match.

(Could also check `github.event_name == 'release' &&`, but this should be enough.)