### PR TITLE
Simplify cache config with 'pip cache dir'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,10 @@ jobs:
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
+            ${{ matrix.os }}-${{ matrix.python-version }}-v2-${{
+            hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+            ${{ matrix.os }}-${{ matrix.python-version }}-v2-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
           python -m pip install --upgrade tox
 
       - name: Tox tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,21 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get pip cache
-        id: pip-cache
-        run: |
-          python -m pip install -U "pip>=20.1"
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
-
       - name: Install Python 3.9
         if: matrix.python-version == '3.9'
         run: |
@@ -53,6 +38,21 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache
+        id: pip-cache
+        run: |
+          python -m pip install -U "pip>=20.1"
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get pip cache
+      - name: Get pip cache dir
         id: pip-cache
         run: |
           python -m pip install -U "pip>=20.1"
           echo "::set-output name=dir::$(pip cache dir)"
 
-      - uses: actions/cache@v1
+      - name: pip cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,22 +22,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Ubuntu cache
-        uses: actions/cache@v1
-        if: startsWith(matrix.os, 'ubuntu')
-        with:
-          path: ~/.cache/pip
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+      - name: Get pip cache
+        id: pip-cache
+        run: |
+          python -m pip install -U "pip>=20.1"
+          echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: macOS cache
-        uses: actions/cache@v1
-        if: startsWith(matrix.os, 'macOS')
+      - uses: actions/cache@v1
         with:
-          path: ~/Library/Caches/pip
+          path: ${{ steps.pip-cache.outputs.dir }}
           key:
             ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
             }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,5 +27,5 @@ git push --tags
 - [ ] Check installation:
 
 ```bash
-pip3 uninstall -y tinytext && pip3 install -U tinytext
+pip3 uninstall -y tinytext && pip3 install -U tinytext && tinytext --version
 ```


### PR DESCRIPTION
Now it's possible to find the cache directory with `pip cache dir` using pip 20.1, which means a lot of cache config can be removed.

This needs pip 20.1+ to be installed first, and so needs Python to be set up first, to make sure it's using the correct Python 3 and not some Python 2 from the default image.

Also install wheel, so pip can create wheels, which should speed up subsequent builds from cache.