### PR TITLE
Fix setuptools_scm generating version 0.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,14 @@ jobs:
       - run: |
           git fetch --prune --unshallow
 
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: deploy-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-pip-
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U setuptools setuptools_scm twine wheel
 
       - name: Build package
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U tox
+          python -m pip install -U setuptools setuptools_scm tox
 
       - name: Lint
         run: tox -e lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.8]
@@ -28,15 +28,15 @@ jobs:
           restore-keys: |
             lint-pre-commit-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade tox
+          python -m pip install -U pip
+          python -m pip install -U tox
 
       - name: Lint
         run: tox -e lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
 
       - name: pip cache
         uses: actions/cache@v1
@@ -40,3 +42,8 @@ jobs:
 
       - name: Lint
         run: tox -e lint
+
+      - name: Check version
+        run: |
+          python setup.py --version
+          [ `python setup.py --version` != "0.0.0" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.1
+    rev: v2.3.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -15,7 +15,7 @@ repos:
         types: []
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -43,7 +43,7 @@ repos:
       - id: mypy
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     package_dir={"": "src"},
     entry_points={"console_scripts": ["tinytext = tinytext.cli:main"]},
     zip_safe=True,
+    setup_requires=["setuptools_scm"],
     extras_require={"tests": ["hypothesis-auto", "pytest", "pytest-cov"]},
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
https://github.com/hugovk/tinytext/pull/31 resulted in https://test.pypi.org/project/tinytext/0.0.0/

> to use `setup.py` as you write, you either need the latest `setuptools` and the latest `setuptools_scm` pre-installed or as `setup_requires` in `setup.py/cfg`,
> 
> `setup.py` invocations will **NOT** install build requirements from `pyproject.toml`
> 
> if you have a modern pip installed, i believe a `pip wheel .` should produce the desired results

https://github.com/pypa/setuptools_scm/issues/386#issuecomment-585075432