### PR TITLE
Revert the no-local-version changes, keep local_scheme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools setuptools_scm twine wheel
+          python -m pip install -U setuptools twine wheel
 
       - name: Build package
         run: |
-          git tag
           python setup.py --version
           python setup.py sdist --format=gztar bdist_wheel
           twine check dist/*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
 
       - name: pip cache
         uses: actions/cache@v1
@@ -35,12 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools setuptools_scm tox
+          python -m pip install -U tox
 
       - name: Lint
         run: tox -e lint
-
-      - name: Check version
-        run: |
-          python setup.py --version
-          [ `python setup.py --version` != "0.0.0" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,2 @@
-[build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.5", "wheel"]
-
 [tool.black]
 target_version = ["py36"]
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ with open("README.md") as f:
     long_description = f.read()
 
 
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
+
+
 setup(
     name="tinytext",
     description="A helpful converter to change any normal text into cuter tinier text",
@@ -24,6 +30,7 @@ setup(
     package_dir={"": "src"},
     entry_points={"console_scripts": ["tinytext = tinytext.cli:main"]},
     zip_safe=True,
+    use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
     extras_require={"tests": ["hypothesis-auto", "pytest", "pytest-cov"]},
     python_requires=">=3.6",


### PR DESCRIPTION
Revert changes from https://github.com/hugovk/tinytext/pull/31 and https://github.com/hugovk/tinytext/pull/33 for now, the last test deploy was also version 0.0.0.

```
Uploading distributions to https://test.pypi.org/legacy/
Uploading tinytext-0.0.0-py3-none-any.whl

  0%|          | 0.00/10.5k [00:00<?, ?B/s]
100%|██████████| 10.5k/10.5k [00:00<00:00, 18.6kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: File already exists. See https://test.pypi.org/help/#file-name-reuse for url: https://test.pypi.org/legacy/
```

https://github.com/hugovk/tinytext/actions/runs/90871992

Keep some of the unrelated changes.
