### PR TITLE
Don't remove automerge label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,4 +25,3 @@ jobs:
         uses: "pascalgn/automerge-action@80acb0f883348dcfd0e526288f7d27a12b9333be"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_REMOVE_LABELS: "automerge"


### PR DESCRIPTION
It seems to actually delete the label from the repo as well, and the label needs to be created again next time.

Hopefully this won't happen now. 