### PR TITLE
GHA: actions/checkout v2.2 can fetch all tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: pip cache
         uses: actions/cache@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.3.0
+    rev: v2.4.4
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -15,7 +15,7 @@ repos:
         types: []
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -31,7 +31,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - python: 3.7
     - python: 3.6
     - python: 3.9-dev
+    - python: 3.10-dev
 
 install:
   - pip install -U pip


### PR DESCRIPTION
* https://github.com/actions/checkout/releases/tag/v2.2.0
* https://github.com/actions/checkout/pull/258

We can remove some config.

Also test on Python 3.10-dev on Travis CI and update pre-commit.