### PR TITLE
GHA: Test on Ubuntu 20.04 LTS (Focal Fossa)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
-        os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-latest]
         include:
           # Include new variables for Codecov
+          - { codecov-flag: GHA_Ubuntu2004, os: ubuntu-20.04 }
           - { codecov-flag: GHA_Ubuntu1804, os: ubuntu-18.04 }
           - { codecov-flag: GHA_Ubuntu1604, os: ubuntu-16.04 }
           - { codecov-flag: GHA_macOS, os: macos-latest }
           # Dev versions
-          - { python-version: 3.9-dev, os: ubuntu-18.04 }
-          - { python-version: 3.10-dev, os: ubuntu-18.04 }
+          - { python-version: 3.9-dev, os: ubuntu-20.04 }
+          - { python-version: 3.10-dev, os: ubuntu-20.04 }
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now available in preview.

> The list of the tools that are not available on Ubuntu 20.04 yet (It should be available in a few weeks):
> 1. Docker
> 2. Pre-cached versions of **Python**, PyPy, Ruby, Node (**setup-python** / UsePython, setup-ruby / UseRuby tasks may not work properly due to that).


https://github.com/actions/virtual-environments/issues/228#issuecomment-637362224

---

However the deadsnakes versions pass ✅

* https://github.com/hugovk/tinytext/blob/e98981b0c126737a766046a4b8a6b4385b02f567/.github/workflows/test.yml#L18-L29