### PR TITLE
Add supporting statement for Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Artistic Software",


### PR DESCRIPTION
I added the Trove supporting statement for Python 3.9 as per #54 , but unfortunately when I attempted to enable "python-3.9" in Travis, it's not available yet, only python-3.9-dev which you're already running against.

Maybe I was too quick, and Travis CI will enable it in the next week or so?