### PR TITLE
Support PyPy3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           - { codecov-flag: GHA_macOS, os: macos-10.15 }
           # Deadsnakes versions
           - { python-version: 3.10-dev, os: ubuntu-20.04 }
+        exclude:
+          # macOS 11.0 is preview, PyPy3 not yet available
+          - { python-version: pypy3, os: macos-11.0 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-11.0, macos-10.15]
         include:
           # Include new variables for Codecov
           - { codecov-flag: GHA_Ubuntu2004, os: ubuntu-20.04 }
           - { codecov-flag: GHA_Ubuntu1804, os: ubuntu-18.04 }
           - { codecov-flag: GHA_Ubuntu1604, os: ubuntu-16.04 }
-          - { codecov-flag: GHA_macOS, os: macos-latest }
+          - { codecov-flag: GHA_macOS, os: macos-10.15 }
           # Deadsnakes versions
           - { python-version: 3.10-dev, os: ubuntu-20.04 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - python: pypy3
     - python: 3.8
     - python: 3.7
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
     setup_requires=["setuptools_scm"],
     extras_require={"tests": ["hypothesis-auto", "pytest", "pytest-cov"]},
     python_requires=">=3.6",
+    project_urls={
+        "Source": "https://github.com/hugovk/tinytext",
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -46,6 +49,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Artistic Software",
         "Topic :: Text Processing",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{39, 38, 37, 36}
+    py{py3, 39, 38, 37, 36}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Also test macOS 11.

macOS 11.0 is in preview, and PyPy3 not yet available, so skip that for now: https://github.com/actions/setup-python/issues/158