### PR TITLE
GHA: Require changelog label on PRs

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,18 @@
+name: Require PR label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels:
+            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
+            Fixed, changelog: Removed, changelog: Security, changelog: skip"


### PR DESCRIPTION
Require one of the "changelog: X" labels on PRs.

https://github.com/mheap/github-action-required-labels