### PR TITLE
Write version to file to avoid overhead of pkg_resources.get_distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ node_modules/
 
 # pyenv
 .python-version
+
+# setuptools_scm
+_version.py

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,8 @@ def local_scheme(version):
 
 
 setup(
-    use_scm_version={"local_scheme": local_scheme},
+    use_scm_version={
+        "local_scheme": local_scheme,
+        "write_to": "src/tinytext/_version.py",
+    },
 )

--- a/src/tinytext/__init__.py
+++ b/src/tinytext/__init__.py
@@ -1,9 +1,6 @@
 from typing import Dict
 
-import pkg_resources
-
-__version__: str = pkg_resources.get_distribution(__name__).version
-
+from ._version import version as __version__  # noqa: F401
 
 tiny_letters: Dict[int, str] = {
     ord("a"): "ᵃ",


### PR DESCRIPTION
Speeds up CLI.

# Python 3.9

## main

```console
$ time tinytext --version
tinytext 2.6.1.dev18
tinytext --version  0.49s user 0.13s system 96% cpu 0.636 total
```

## PR

```console
$ time tinytext --version
tinytext 2.6.1.dev18
tinytext --version  0.09s user 0.03s system 94% cpu 0.122 total
```

-> 5.2 times faster

# Python 3.10

## main

```console
$ time tinytext --version
tinytext 2.6.1.dev18
tinytext --version  0.48s user 0.12s system 97% cpu 0.614 total
```

## PR

```console
$ time tinytext --version
tinytext 2.6.1.dev18
tinytext --version  0.09s user 0.03s system 95% cpu 0.119 total
```

-> 5.0 times faster
