### PR TITLE
Dependabot: Only major update for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,19 @@ updates:
       time: "03:00"
     open-pull-requests-limit: 10
     labels:
-      - dependencies
       - "changelog: skip"
+      - "dependencies"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: monthly
-      time: "03:00"
+      interval: daily
+      time: "16:55"
     open-pull-requests-limit: 10
     labels:
       - "changelog: skip"
-      - dependencies
+      - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
Docs:

* https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore
