### PR TITLE
CI: Add final noop job to mark as required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,11 @@ jobs:
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+  success:
+    needs: test
+    runs-on: ubuntu-latest
+    name: test successful
+    steps:
+      - name: Success
+        run: echo Test successful


### PR DESCRIPTION
To simplify required checks in branch protection rules.

![image](https://user-images.githubusercontent.com/1324225/171658952-cc712a3e-52c7-449b-8c3b-8685553e91cd.png)

