### PR TITLE
Remove default "user: __token__"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,12 +40,10 @@ jobs:
         if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.pypi_password }}
 
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
These are now removed from the docs at https://github.com/pypa/gh-action-pypi-publish because it's the default.