### PR TITLE
Update pyproject-fmt and Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,9 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
-        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
           [flake8-2020, flake8-errmsg, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
       - id: python-no-log-warn
@@ -47,17 +47,17 @@ repos:
         args: [--strict, --pretty, --show-error-codes]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.4.1
+    rev: 0.6.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
+    rev: v0.12.1
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.2
+    rev: 0.6.1
     hooks:
       - id: tox-ini-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,6 @@ keywords = [
 license = {text = "MIT"}
 authors = [{name = "Hugo van Kemenade"}]
 requires-python = ">=3.7"
-dependencies = [
-  'importlib-metadata; python_version < "3.8"',
-]
-dynamic = [
-  "version",
-]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -41,6 +35,12 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Artistic Software",
     "Topic :: Text Processing",
+]
+dynamic = [
+  "version",
+]
+dependencies = [
+  'importlib-metadata; python_version < "3.8"',
 ]
 [project.optional-dependencies]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,6 @@ Source = "https://github.com/hugovk/tinytext"
 tinytext = "tinytext.cli:main"
 
 
-[tool.black]
-target_version = ["py37"]
-
 [tool.hatch]
 version.source = "vcs"
 


### PR DESCRIPTION
We can use Black's new `target-version` inference to remove some config:

https://ichard26.github.io/blog/2023/01/black-23.1.0/#better-default-for---target-version-if-pep-621-python-requires-is-available