### PR TITLE
CI: Replace pypy3.9 with pypy3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [macos-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos