### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# hatch-vcs
+src/tinytext/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ scripts.tinytext = "tinytext.cli:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/tinytext/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/tinytext/__init__.py
+++ b/src/tinytext/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import importlib.metadata
+from tinytext import _version  # type: ignore[attr-defined]
 
-__version__ = importlib.metadata.version(__name__)
+__version__ = _version.__version__
 
 
 __all__ = ["__version__"]


### PR DESCRIPTION
With Python 3.12.4:

```sh
python -X importtime -c "import tinytext" 2> import.log && tuna import.log
```

Cuts out the 22ms `importlib.metadata` import.

# `main`

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/042a2bf7-a842-4ec2-93f2-6ede3a8f1451">

```console
❯ hyperfine -w 8 "tinytext --version"
Benchmark 1: tinytext --version
  Time (mean ± σ):      49.2 ms ±   3.7 ms    [User: 38.2 ms, System: 9.5 ms]
  Range (min … max):    45.1 ms …  66.4 ms    62 runs
```

# PR

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ef4c7669-cb92-4038-bb06-3b18537b7926">

```console
❯ hyperfine -w 8 "tinytext --version"
Benchmark 1: tinytext --version
  Time (mean ± σ):      26.4 ms ±   1.0 ms    [User: 19.8 ms, System: 5.5 ms]
  Range (min … max):    24.6 ms …  29.1 ms    105 runs
```

