### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ permissions:
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   test:
@@ -15,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system -U tox-uv
+          uv venv
+          uv pip install -U tox-uv
 
       - name: Tox tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Tox tests
         run: |
-          tox -e py
+          .venv/bin/tox -e py
 
       - name: Test CLI
         run: |
-          tox -e cli
+          .venv/bin/tox -e cli
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,13 @@ keywords = [
 ]
 license = { text = "MIT" }
 authors = [ { name = "Hugo van Kemenade" } ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     cli
     lint
     mypy
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan