### PR TITLE
Use pre-commit-uv for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -15,11 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: hugovk/pre-commit-action-uv@v3.0.1
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Before

No Actions cache: 1m 6s

https://github.com/hugovk/tinytext/actions/runs/11307458441/job/31449206647

With Actions cache: 13s

https://github.com/hugovk/tinytext/actions/runs/11307515313/job/31449323869

# After

No Actions cache: 50s

https://github.com/hugovk/tinytext/actions/runs/11307553771/job/31449400169

With Actions cache: 13s

https://github.com/hugovk/tinytext/actions/runs/11307560729/job/31449415202