### PR TITLE
Add numerical digits superscript conversion

### DIFF
--- a/src/tinytext/__init__.py
+++ b/src/tinytext/__init__.py
@@ -4,7 +4,17 @@ from ._version import __version__
 
 __all__ = ["__version__"]
 
-tiny_letters: dict[int, str] = {
+tiny_characters: dict[int, str] = {
+    ord("0"): "⁰",
+    ord("1"): "¹",
+    ord("2"): "²",
+    ord("3"): "³",
+    ord("4"): "⁴",
+    ord("5"): "⁵",
+    ord("6"): "⁶",
+    ord("7"): "⁷",
+    ord("8"): "⁸",
+    ord("9"): "⁹",
     ord("a"): "ᵃ",
     ord("b"): "ᵇ",
     ord("c"): "ᶜ",
@@ -85,5 +95,5 @@ tiny_letters: dict[int, str] = {
 
 def tinytext(big: str) -> str:
     """convert your text ᶦᶰᵗᵒ ᵗᶦᶰᶦᵉʳ ᵗᵉˣᵗ"""
-    tiny: str = big.translate(tiny_letters)
+    tiny: str = big.translate(tiny_characters)
     return tiny

--- a/tests/test_tinytext.py
+++ b/tests/test_tinytext.py
@@ -12,9 +12,12 @@ def test_something() -> None:
     # Assert
     assert tiny == "ᶦᶰᵗᵒ ᵗᶦᶰᶦᵉʳ ᵗᵉˣᵗ"
 
+
 def test_for_digits() -> None:
     # Arrange
-    numbers = ''.join(str(character) for character in range(9, -1, -1))      # numbers = 9876543210
+    numbers = "".join(
+        str(character) for character in range(9, -1, -1)
+    )  # numbers = 9876543210
 
     # Act
     tiny: str = tinytext.tinytext(numbers)

--- a/tests/test_tinytext.py
+++ b/tests/test_tinytext.py
@@ -11,3 +11,13 @@ def test_something() -> None:
 
     # Assert
     assert tiny == "ᶦᶰᵗᵒ ᵗᶦᶰᶦᵉʳ ᵗᵉˣᵗ"
+
+def test_for_digits() -> None:
+    # Arrange
+    numbers = ''.join(str(character) for character in range(9, -1, -1))      # numbers = 9876543210
+
+    # Act
+    tiny: str = tinytext.tinytext(numbers)
+
+    # Assert
+    assert tiny == "⁹⁸⁷⁶⁵⁴³²¹⁰"

--- a/tests/test_tinytext.py
+++ b/tests/test_tinytext.py
@@ -15,9 +15,7 @@ def test_something() -> None:
 
 def test_for_digits() -> None:
     # Arrange
-    numbers = "".join(
-        str(character) for character in range(9, -1, -1)
-    )  # numbers = 9876543210
+    numbers = "9876543210"
 
     # Act
     tiny: str = tinytext.tinytext(numbers)


### PR DESCRIPTION
This Pull Request adds an superscript equivalent support to the digits 0-9 from the English Keyboard with their equivalent tiny unicode superscripts added in the newly renamed tiny_characters (from tiny_letters) dictionary collection, and includes a testcase for testing these digits coversion as well.

I have directly raised it as a pull request for the feature addition, since there was no CONTRIBUTING.md asking for an issue first, but a reviewer can indicate if those entries are also needed for it and I can help with it. Please have a review and let me know of your comments, if any.