### PR TITLE
Only create PyPI digital attestations (PEP 740)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -50,11 +49,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -71,7 +65,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -80,11 +73,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
+  RUFF_OUTPUT_FORMAT: github
 
 permissions: {}
 

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -18,10 +18,10 @@ jobs:
           mode: minimum
           count: 1
           labels: |
-            "changelog: Added"
-            "changelog: Changed"
-            "changelog: Deprecated"
-            "changelog: Fixed"
-            "changelog: Removed"
-            "changelog: Security"
-            "changelog: skip"
+            changelog: Added
+            changelog: Changed
+            changelog: Deprecated
+            changelog: Fixed
+            changelog: Removed
+            changelog: Security
+            changelog: skip


### PR DESCRIPTION
Generating PyPI's digital attestations should be enough (https://docs.pypi.org/attestations/), we don't _also_ need to use https://github.com/actions/attest-build-provenance.