### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/tinytext/cli.py
+++ b/src/tinytext/cli.py
@@ -14,6 +14,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    parser.color = True  # type: ignore[attr-defined]
     parser.add_argument("text", help="Text to tinify")
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color

<img width="864" alt="image" src="https://github.com/user-attachments/assets/dfc696ef-06ba-403c-b113-f06fe926aca3" />
