### PR TITLE
Migrate from package extras to dependency groups

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# Configuration for the zizmor static analysis tool, run via pre-commit in CI
+# https://woodruffw.github.io/zizmor/configuration/
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.13
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
@@ -37,12 +37,12 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.5.2
+    rev: v1.9.0
     hooks:
       - id: zizmor
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: pyproject-fmt
 
@@ -57,7 +57,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/google/yamlfmt
-    rev: v0.16.0
+    rev: v0.17.0
     hooks:
       - id: yamlfmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,23 @@ classifiers = [
   "Topic :: Text Processing",
 ]
 dynamic = [ "version" ]
-optional-dependencies.tests = [
-  "pytest",
-  "pytest-cov",
-]
 urls.Changelog = "https://github.com/hugovk/tinytext/releases"
 urls.Homepage = "https://github.com/hugovk/tinytext"
 urls.Source = "https://github.com/hugovk/tinytext"
 scripts.tinytext = "tinytext.cli:main"
+
+[dependency-groups]
+dev = [
+  { include-group = "tests" },
+  { include-group = "typing" },
+]
+tests = [
+  "pytest",
+  "pytest-cov",
+]
+typing = [
+  "mypy",
+]
 
 [tool.hatch]
 version.source = "vcs"
@@ -83,7 +92,7 @@ lint.ignore = [
   "E221",   # Multiple spaces before operator
   "E226",   # Missing whitespace around arithmetic operator
   "E241",   # Multiple spaces after ','
-  "PIE790", # flake8-pie: unnecessary-placeholder
+  "PIE790", # Unnecessary pass statement
   "UP038",  # Makes code slower and more verbose
 ]
 lint.per-file-ignores."tests/**/*.py" = [


### PR DESCRIPTION
Instead of `pip install -e .[tests]` run `pip install -e --group tests`. 

Similarly with `uv pip install`.